### PR TITLE
Added dpkg --add-architecture i386 for 64 arch

### DIFF
--- a/ubuntu_ionic_installer.sh
+++ b/ubuntu_ionic_installer.sh
@@ -29,6 +29,11 @@ ANDROID_SDK_X86="http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz"
 NODE_X64="http://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x64.tar.gz"
 NODE_X86="http://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x86.tar.gz"
 
+if [ "$LINUX_ARCH" == "x86_64" ]; then
+    # Add i386 architecture
+    dpkg --add-architecture i386
+fi
+
 # Update all Ubuntu software repository lists
 apt-get update
 


### PR DESCRIPTION
Some commonly used Ubuntu images (e.g. Ubuntu Server 14.04 LTS AMI
on AWS) had trouble installing i-386 packages with a precedent
dpkg command as in this commit.
